### PR TITLE
Move old docs 2 library

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ For more information on anything Axon, please visit our website, [http://axoniq.
 
 ## Getting started
 
-The [reference guide](https://docs.axoniq.io) contains a separate chapter for all the extensions.
-The JobRunr Pro extension description can be found [here](https://docs.axoniq.io/reference-guide/extensions/jobrunrpro).
+The [AxonIQ Library](https://library.axoniq.io) contains a section for the guides of all the Axon Framework extensions.
+The JobRunr Pro Extension guide can be found [here](https://library.axoniq.io/home/guides/axon-framework.html).
 
 ## Receiving help
 
@@ -31,11 +31,10 @@ Are you having trouble using the extension?
 We'd like to help you out the best we can!
 There are a couple of things to consider when you're traversing anything Axon:
 
-* Checking the [reference guide](https://docs.axoniq.io/reference-guide/extensions/jobrunrpro) should be your first
-  stop,
+* Checking the [reference guide](https://library.axoniq.io/axon_framework_old_ref/) should be your first stop,
   as the majority of possible scenarios you might encounter when using Axon should be covered there.
 * If the Reference Guide does not cover a specific topic you would've expected,
-  we'd appreciate if you could file an [issue](https://github.com/AxonIQ/reference-guide/issues) about it for us.
+  we'd appreciate if you could post a [new thread/topic on our library fourms describing the problem](https://discuss.axoniq.io/c/26).
 * There is a [forum](https://discuss.axoniq.io/) to support you in the case the reference guide did not sufficiently
   answer your question.
   Axon Framework and Server developers will help out on a best effort basis.

--- a/docs/_playbook/.gitignore
+++ b/docs/_playbook/.gitignore
@@ -1,0 +1,4 @@
+build
+node_modules
+.vscode
+vale

--- a/docs/_playbook/.gitignore
+++ b/docs/_playbook/.gitignore
@@ -2,3 +2,4 @@ build
 node_modules
 .vscode
 vale
+

--- a/docs/_playbook/.gitignore
+++ b/docs/_playbook/.gitignore
@@ -2,4 +2,4 @@ build
 node_modules
 .vscode
 vale
-
+package-lock.json

--- a/docs/_playbook/.vale.ini
+++ b/docs/_playbook/.vale.ini
@@ -1,0 +1,24 @@
+StylesPath = vale
+
+MinAlertLevel = suggestion
+
+Packages = http://github.com/AxonIQ/axoniq-vale-package/releases/latest/download/axoniq-vale-package.zip
+
+Vocab = general, AxonIQ, Java, Names_Terms, misc
+
+[*.{adoc,html}]
+BasedOnStyles = AxonIQ, proselint, Google
+
+Google.Headings = NO # Diasable in favor od AxonIQ one
+Google.Parens = NO # Disable warning about using parens
+Google.Quotes = NO # Diasable "commas and periods go inside quotation marks"
+Google.WordList = NO # Disable Google's word list
+Google.Passive = NO # Allow the use of Passive voice
+Google.Colons = NO # Allow the use of Colons
+Google.Will = NO # Allow use will
+Google.Contractions = NO
+Google.We = NO
+
+
+AxonIQ.AcronymCase = NO
+AxonIQ.HeadingTitle = NO

--- a/docs/_playbook/package.json
+++ b/docs/_playbook/package.json
@@ -1,0 +1,11 @@
+{
+  "devDependencies": {
+    "@antora/atlas-extension": "^1.0.0-alpha.2",
+    "@antora/cli": "^3.2.0-alpha.2",
+    "@antora/lunr-extension": "^1.0.0-alpha.8",
+    "@antora/site-generator": "^3.2.0-alpha.2",
+    "@asciidoctor/tabs": "^1.0.0-beta.6",
+    "@axoniq/antora-vale-extension": "^0.1.1",
+    "asciidoctor-kroki": "^0.17.0"
+  }
+}

--- a/docs/_playbook/playbook.yaml
+++ b/docs/_playbook/playbook.yaml
@@ -1,0 +1,42 @@
+site:
+  title: JobRunr Pro Extension docs PREVIEW
+  start_page: jobrunrpro_extension_old_ref::index.adoc
+
+content:
+  sources:
+  - url: ../..
+    start_paths: ['docs/*', '!docs/_*']
+
+asciidoc:
+  attributes:
+    experimental: true
+    page-pagination: true
+    kroki-fetch-diagram: true
+  #   primary-site-manifest-url: https://library.axoniq.io/site-manifest.json
+  extensions:
+    - asciidoctor-kroki
+    - '@asciidoctor/tabs'
+
+antora:
+  extensions:
+    - id: prose-linting
+      require: '@axoniq/antora-vale-extension'
+      enabled: true
+      vale_config: .vale.ini
+      update_styles: true
+    - id: lunr
+      require: '@antora/lunr-extension'
+      enabled: true
+      index_latest_only: true
+    - id: atlas
+      require: '@antora/atlas-extension'
+
+runtime:
+  fetch: true # fetch remote repos
+  log:
+    level: info
+    failure_level: error
+
+ui:
+  bundle:
+    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.0.1.9/ui-bundle.zip

--- a/docs/old-reference-guide/antora.yml
+++ b/docs/old-reference-guide/antora.yml
@@ -1,0 +1,14 @@
+name: jobrunrpro_extension_old_ref
+title: JobRunr Pro Extension Guide
+version: true
+prerelease: true
+start_page: ROOT:index.adoc
+
+asciidoc:
+  attributes:
+    component_description: The JobRunr Pro Extension guide from the former reference guide
+    type: guide
+    group: axon-framework
+
+nav:
+  - modules/nav.adoc

--- a/docs/old-reference-guide/modules/ROOT/pages/index.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/index.adoc
@@ -1,0 +1,54 @@
+:navtitle: JobRunr Pro Extension
+= JobRunr Pro
+
+The purpose of this extension is to leverage some features only available in the Pro version of link:https://www.jobrunr.io/en/documentation/pro/[JobRunr,window=_blank,role=external]. Only the Pro version allows to search existing jobs by status and label. This is required for the deadline manager to implement the `cancelAll` methods. The xref:axon_framework_old_ref:deadlines:deadline-managers.adoc[deadline managers] section has more in depth information on deadline managers. Although jobs created with the non-pro `DeadlineManager` will be eligible to be canceled, this is only true when they were created with the `4.8` or later versions. Jobs created with the `4.7.x` version are missing the correct labels and will not be found when trying to cancel them.
+
+
+== Spring usage
+
+For Spring usage, be sure to include the starters, both of JobRunr Pro and the extension. The deadline manager should be available by using parameter-based injection. It can be used in aggregates and sagas using something like:
+
+[tabs]
+======
+Aggregate::
++
+[source,java]
+----
+@CommandHandler
+public void handle(SomeCommand command, @Autowired DeadlineManager deadlineManager) { ... }
+----
+
+Saga::
++
+--
+[source,java]
+----
+@StartSaga
+public void handle(SomeEvent event, @Autowired DeadlineManager deadlineManager) { ... }
+----
+
+Alternatively, you could also auto wire the deadline manager to the class like:
+[source, java]
+----
+@Autowired
+void setDeadlineManager(DeadlineManager deadlineManager) {
+    this.deadlineManager = deadlineManager;
+}
+----
+======
+
+== Non Spring usage
+An JobRunrProDeadlineManager instance can be created using the builder like this:
+
+[source,java]
+----
+JobRunrProDeadlineManager.proBuilder()
+        .jobScheduler(jobScheduler)
+        .storageProvider(storageProvider)
+        .scopeAwareProvider(scopeAwareProvider)
+        .serializer(serializer)
+        .transactionManager(transactionManager)
+        .spanFactory(spanFactory)
+        .build();
+----
+You probably want to use some form of dependency injection instead of creating a new deadline manager each time you need one.

--- a/docs/old-reference-guide/modules/nav.adoc
+++ b/docs/old-reference-guide/modules/nav.adoc
@@ -1,4 +1,1 @@
 * xref:ROOT:index.adoc[]
-** xref:ROOT:forwarding.adoc[]
-** xref:ROOT:reading.adoc[]
-

--- a/docs/old-reference-guide/modules/nav.adoc
+++ b/docs/old-reference-guide/modules/nav.adoc
@@ -1,0 +1,4 @@
+* xref:ROOT:index.adoc[]
+** xref:ROOT:forwarding.adoc[]
+** xref:ROOT:reading.adoc[]
+


### PR DESCRIPTION
Moved contents from Extensions > JobRunr Pro in the old docs.axoniq.io here to be published with antora under library.axoniq.io > Guides > Axon Framework > JobRunner Pro 