### PR TITLE
Upgrade to JobRunr 7.2.2

### DIFF
--- a/jobrunrpro-spring-boot-3-integrationtests/pom.xml
+++ b/jobrunrpro-spring-boot-3-integrationtests/pom.xml
@@ -38,7 +38,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <jobrunr.version>6.0.0</jobrunr.version>
+        <jobrunr.version>7.2.2</jobrunr.version>
         <axon.version>4.10.0</axon.version>
         <jococo.version>0.8.11</jococo.version>
         <testcontainers.version>1.20.1</testcontainers.version>

--- a/jobrunrpro/src/main/java/org/axonframework/extensions/jobrunrpro/util/JobRunrProUtils.java
+++ b/jobrunrpro/src/main/java/org/axonframework/extensions/jobrunrpro/util/JobRunrProUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.jobrunr.storage.StorageProvider;
 import java.util.List;
 
 import static org.jobrunr.storage.JobSearchRequestBuilder.aJobSearchRequest;
-import static org.jobrunr.storage.PageRequest.ascOnUpdatedAt;
+import static org.jobrunr.storage.Paging.OffsetBasedPage.ascOnUpdatedAt;
 
 /**
  * Utility methods specifically for JobRunr Pro

--- a/jobrunrpro/src/test/java/org/axonframework/extensions/jobrunrpro/deadline/JobRunrProDeadlineManagerTest.java
+++ b/jobrunrpro/src/test/java/org/axonframework/extensions/jobrunrpro/deadline/JobRunrProDeadlineManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010-2023. Axon Framework
+ * Copyright (c) 2010-2024. Axon Framework
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ import org.axonframework.serialization.TestSerializer;
 import org.jobrunr.scheduling.JobScheduler;
 import org.jobrunr.storage.JobSearchRequest;
 import org.jobrunr.storage.Page;
-import org.jobrunr.storage.PageRequest;
 import org.jobrunr.storage.StorageProvider;
+import org.jobrunr.storage.navigation.PageRequest;
 import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         </sonar.coverage.jacoco.xmlReportPaths>
 
         <axon.version>4.10.0</axon.version>
-        <jobrunr.version>6.3.5</jobrunr.version>
+        <jobrunr.version>7.2.2</jobrunr.version>
 
         <spring.version>5.3.39</spring.version>
         <spring.boot.version>2.7.18</spring.boot.version><!-- Don't upgrade due to JDK8 -->


### PR DESCRIPTION
This pull request upgrades the JobRunr version to 7.2.2 (current latest).
Next to that, it fixes two import statements that where adjusted between the last major release of JobRunr this project used.